### PR TITLE
Declare TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+// See https://github.com/xuoe/redux-observers/issues/5
+import { Dispatch, Store, Unsubscribe } from 'redux';
+
+export function shallowEquals(a: any, b: any): boolean;
+
+interface Options {
+  skipInitialCall?: boolean;
+  equals?: typeof shallowEquals;
+}
+
+type Observer<S = any, MS = any> = unknown;
+type Mapper<S = any, MS = any> = (state: S) => MS;
+type Dispatcher<MS> = (dispatch: Dispatch<MS>, currentState: MS, previousState: MS) => unknown;
+
+export function observer<S, MS>(mapper: Mapper<S, MS>, dispatcher: Dispatcher<MS>, options?: Options): Observer<S, MS>;
+export function observer<S>(dispatcher: Dispatcher<S>, options?: Options): Observer<S, S>;
+
+export function observe<S>(store: Store<S>, observers: Observer[], options?: Options): Unsubscribe;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "babel src --out-dir lib",
     "clean": "rimraf lib coverage",
@@ -37,5 +38,8 @@
   "keywords": [
     "redux",
     "observer"
-  ]
+  ],
+  "dependencies": {
+    "@types/redux": "^3.6.0"
+  }
 }


### PR DESCRIPTION
Fixes #5

---
Note that for supporting redux 4 this will require changes:
* drop the added dependency 
* replace `Dispatch<MS>` with `Dispatch` in the `Dispatcher<MS>` signature