### PR TITLE
Refresh the state between observer runs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,10 +31,9 @@ export function observe(store, observers, options = {}) {
   }, {})
 
   const { dispatch, getState, subscribe } = store
-  const apply = state => {
-    observers.forEach(fn => { fn(state, dispatch, globals) })
+  const listen = () => {
+    observers.forEach(fn => { fn(getState(), dispatch, globals) })
   }
-  const listen = () => { apply(getState()) }
 
   const unsubscribe = subscribe(listen)
   listen()


### PR DESCRIPTION
This fixes a case where observer B depends on A and sets it's state from it, and C depends on B and attempts to set it's state from it. Previously, the C did not get the updated state, after the B set action was handled, whereas now each observer gets the most recent state.